### PR TITLE
Optimize xml comments

### DIFF
--- a/src/DotSwashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentDescriptor.cs
+++ b/src/DotSwashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentDescriptor.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+
+namespace DotSwashbuckle.AspNetCore.SwaggerGen.XmlComments
+{
+    public record XmlCommentDescriptor
+    {
+        public string Summary { get; set; }
+        public string Remarks { get; set; }
+        public string Example { get; set; }
+        public List<XmlParam> Params { get; set; }
+        public List<XmlResponse> Responses { get; set; }
+
+    }
+
+    public record XmlParam
+    {
+        public string Value { get; set; }
+        public string Name { get; set; }
+        public string Example { get; set; }
+    }
+
+    public record XmlResponse
+    {
+        public string Code { get; set; }
+        public string Description { get; set; }
+    }
+}

--- a/src/DotSwashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentFilter.cs
+++ b/src/DotSwashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentFilter.cs
@@ -1,23 +1,16 @@
-﻿using System.Xml.XPath;
-using System.Linq;
+﻿using System.Linq;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.OpenApi.Models;
 using System;
+using DotSwashbuckle.AspNetCore.SwaggerGen.XmlComments;
 
 namespace DotSwashbuckle.AspNetCore.SwaggerGen
 {
-    public class XmlCommentsDocumentFilter : IDocumentFilter
+    public class XmlCommentsDocumentFilter(
+        IReadOnlyDictionary<string, XmlCommentDescriptor> xmlMemberDescriptors
+    ) : IDocumentFilter
     {
-        private const string MemberXPath = "/doc/members/member[@name='{0}']";
-        private const string SummaryTag = "summary";
-
-        private readonly XPathNavigator _xmlNavigator;
-
-        public XmlCommentsDocumentFilter(XPathDocument xmlDoc)
-        {
-            _xmlNavigator = xmlDoc.CreateNavigator();
-        }
 
         public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
         {
@@ -31,22 +24,21 @@ namespace DotSwashbuckle.AspNetCore.SwaggerGen
             foreach (var nameAndType in controllerNamesAndTypes)
             {
                 var memberName = XmlCommentsNodeNameHelper.GetMemberNameForType(nameAndType.Value);
-                var typeNode = _xmlNavigator.SelectSingleNode(string.Format(MemberXPath, memberName));
 
-                if (typeNode != null)
+                if (!xmlMemberDescriptors.TryGetValue(memberName, out var xmlCommentDescriptor))
                 {
-                    var summaryNode = typeNode.SelectSingleNode(SummaryTag);
-                    if (summaryNode != null)
-                    {
-                        if (swaggerDoc.Tags == null)
-                            swaggerDoc.Tags = new List<OpenApiTag>();
+                    continue;
+                }
 
-                        swaggerDoc.Tags.Add(new OpenApiTag
-                        {
-                            Name = nameAndType.Key,
-                            Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml)
-                        });
-                    }
+                if (!string.IsNullOrWhiteSpace(xmlCommentDescriptor.Summary))
+                {
+                    swaggerDoc.Tags ??= new List<OpenApiTag>();
+
+                    swaggerDoc.Tags.Add(new OpenApiTag
+                    {
+                        Name = nameAndType.Key,
+                        Description = XmlCommentsTextHelper.Humanize(xmlCommentDescriptor.Summary)
+                    });
                 }
             }
         }

--- a/test/DotSwashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsDocumentFilterTests.cs
+++ b/test/DotSwashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsDocumentFilterTests.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.IO;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using Xunit;
 
@@ -45,10 +46,7 @@ namespace DotSwashbuckle.AspNetCore.SwaggerGen.Test
 
         private XmlCommentsDocumentFilter Subject()
         {
-            using (var xmlComments = File.OpenText($"{typeof(FakeControllerWithXmlComments).Assembly.GetName().Name}.xml"))
-            {
-                return new XmlCommentsDocumentFilter(new XPathDocument(xmlComments));
-            }
+            return new XmlCommentsDocumentFilter(SwaggerGenOptionsExtensions.ParseXmlCommentDescriptors($"{typeof(FakeControllerWithXmlComments).Assembly.GetName().Name}.xml"));
         }
     }
 }

--- a/test/DotSwashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsOperationFilterTests.cs
+++ b/test/DotSwashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsOperationFilterTests.cs
@@ -5,6 +5,7 @@ using Microsoft.OpenApi.Models;
 using Xunit;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using DotSwashbuckle.AspNetCore.TestSupport;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DotSwashbuckle.AspNetCore.SwaggerGen.Test
 {
@@ -75,10 +76,7 @@ namespace DotSwashbuckle.AspNetCore.SwaggerGen.Test
 
         private XmlCommentsOperationFilter Subject()
         {
-            using (var xmlComments = File.OpenText(typeof(FakeControllerWithXmlComments).Assembly.GetName().Name + ".xml"))
-            {
-                return new XmlCommentsOperationFilter(new XPathDocument(xmlComments));
-            }
+            return new XmlCommentsOperationFilter(SwaggerGenOptionsExtensions.ParseXmlCommentDescriptors($"{typeof(FakeControllerWithXmlComments).Assembly.GetName().Name}.xml"));
         }
     }
 }

--- a/test/DotSwashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsParameterFilterTests.cs
+++ b/test/DotSwashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsParameterFilterTests.cs
@@ -3,6 +3,7 @@ using System.Xml.XPath;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.OpenApi.Models;
 using DotSwashbuckle.AspNetCore.TestSupport;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace DotSwashbuckle.AspNetCore.SwaggerGen.Test
@@ -94,10 +95,7 @@ namespace DotSwashbuckle.AspNetCore.SwaggerGen.Test
 
         private XmlCommentsParameterFilter Subject()
         {
-            using (var xmlComments = File.OpenText(typeof(FakeControllerWithXmlComments).Assembly.GetName().Name + ".xml"))
-            {
-                return new XmlCommentsParameterFilter(new XPathDocument(xmlComments));
-            }
+            return new XmlCommentsParameterFilter((SwaggerGenOptionsExtensions.ParseXmlCommentDescriptors($"{typeof(FakeControllerWithXmlComments).Assembly.GetName().Name}.xml")));
         }
     }
 }

--- a/test/DotSwashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsRequestBodyFilterTests.cs
+++ b/test/DotSwashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsRequestBodyFilterTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 using DotSwashbuckle.AspNetCore.TestSupport;
 using System.Collections.Generic;
 using System;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DotSwashbuckle.AspNetCore.SwaggerGen.Test
 {
@@ -112,10 +113,7 @@ namespace DotSwashbuckle.AspNetCore.SwaggerGen.Test
         }
         private XmlCommentsRequestBodyFilter Subject()
         {
-            using (var xmlComments = File.OpenText(typeof(FakeControllerWithXmlComments).Assembly.GetName().Name + ".xml"))
-            {
-                return new XmlCommentsRequestBodyFilter(new XPathDocument(xmlComments));
-            }
+            return new XmlCommentsRequestBodyFilter(SwaggerGenOptionsExtensions.ParseXmlCommentDescriptors($"{typeof(FakeControllerWithXmlComments).Assembly.GetName().Name}.xml"));
         }
     }
 }

--- a/test/DotSwashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
+++ b/test/DotSwashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using Microsoft.OpenApi.Models;
 using Xunit;
 using DotSwashbuckle.AspNetCore.TestSupport;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DotSwashbuckle.AspNetCore.SwaggerGen.Test
 {
@@ -109,10 +110,7 @@ namespace DotSwashbuckle.AspNetCore.SwaggerGen.Test
 
         private XmlCommentsSchemaFilter Subject()
         {
-            using (var xmlComments = File.OpenText(typeof(XmlAnnotatedType).Assembly.GetName().Name + ".xml"))
-            {
-                return new XmlCommentsSchemaFilter(new XPathDocument(xmlComments));
-            }
+            return new XmlCommentsSchemaFilter(SwaggerGenOptionsExtensions.ParseXmlCommentDescriptors($"{typeof(FakeControllerWithXmlComments).Assembly.GetName().Name}.xml"));
         }
     }
 }


### PR DESCRIPTION
Optimized Dummy website allocations from 4.6GB to 245Mb and improved runtime performance from 4.6seconds to 637ms.

> 
| Method                | Mean     | Error   | StdDev  | Gen0       | Gen1      | Allocated |
|---------------------- |---------:|--------:|--------:|-----------:|----------:|----------:|
| DotSwashbuckleOpenApi | 637.7 ms | 5.32 ms | 4.16 ms | 15000.0000 | 4000.0000 | 245.53 MB |